### PR TITLE
Cycle through characters in PlayHome POV

### DIFF
--- a/src/RealPOV.PlayHome/PointOfView.cs
+++ b/src/RealPOV.PlayHome/PointOfView.cs
@@ -11,7 +11,8 @@ namespace RealPOV.PlayHome
         private static bool lockNormalCamera;
         private static Human currentTarget;
         private static Female female;
-        private static Male male;
+        private static Human[] targets;
+        private static int currentTargetIndex = 0;
 
         private bool OnUI => EventSystem.current && EventSystem.current.IsPointerOverGameObject();
         private bool dragging;
@@ -52,6 +53,25 @@ namespace RealPOV.PlayHome
 
             if(lockNormalCamera)
             {
+                if(RealPOV.CycleNextHotkey.Value.IsDown())
+                {
+                    Restore();
+                    currentTargetIndex++;
+                    if(currentTargetIndex >= targets.Length) {
+                        currentTargetIndex = 0;
+                    }
+                    SetPOV();
+                }
+                else if(RealPOV.CyclePrevHotkey.Value.IsDown())
+                {
+                    Restore();
+                    currentTargetIndex--;
+                    if(currentTargetIndex < 0) {
+                        currentTargetIndex = targets.Length - 1;
+                    }
+                    SetPOV();
+                }
+
                 if(currentTarget)
                     UpdateCamera();
                 else
@@ -64,8 +84,20 @@ namespace RealPOV.PlayHome
             if(!lockNormalCamera)
             {
                 female = FindObjectOfType<Female>();
-                male = FindObjectOfType<Male>();
-                currentTarget = male;
+                if(RealPOV.IncludeFemalePOV.Value)
+                {
+                    targets = FindObjectsOfType<Human>();
+                }
+                else
+                {
+                    targets = FindObjectsOfType<Male>();
+                }
+
+                if(currentTargetIndex > targets.Length - 1)
+                {
+                    currentTargetIndex = 0;
+                }
+                currentTarget = targets[currentTargetIndex];
 
                 if(currentTarget)
                 {

--- a/src/RealPOV.PlayHome/RealPOV.cs
+++ b/src/RealPOV.PlayHome/RealPOV.cs
@@ -4,6 +4,7 @@ using BepInEx.Configuration;
 using HarmonyLib;
 using KeelPlugins.Utils;
 using RealPOV.Core;
+using UnityEngine;
 
 [assembly: System.Reflection.AssemblyFileVersion(RealPOV.PlayHome.RealPOV.Version)]
 
@@ -22,6 +23,9 @@ namespace RealPOV.PlayHome
         internal static ConfigEntry<float> MaleOffsetX { get; set; }
         internal static ConfigEntry<float> MaleOffsetY { get; set; }
         internal static ConfigEntry<float> MaleOffsetZ { get; set; }
+        internal static ConfigEntry<KeyboardShortcut> CycleNextHotkey { get; set; }
+        internal static ConfigEntry<KeyboardShortcut> CyclePrevHotkey { get; set; }
+        internal static ConfigEntry<bool> IncludeFemalePOV { get; set; }
 
         protected override void Awake()
         {
@@ -34,6 +38,10 @@ namespace RealPOV.PlayHome
             MaleOffsetX = Config.Bind(SECTION_OFFSETS, "Male offset X", 0f, new ConfigDescription("", null, new ConfigurationManagerAttributes { IsAdvanced = true }));
             MaleOffsetY = Config.Bind(SECTION_OFFSETS, "Male offset Y", 0.092f, new ConfigDescription("", null, new ConfigurationManagerAttributes { IsAdvanced = true }));
             MaleOffsetZ = Config.Bind(SECTION_OFFSETS, "Male offset Z", 0.12f, new ConfigDescription("", null, new ConfigurationManagerAttributes { IsAdvanced = true }));
+
+            CycleNextHotkey = Config.Bind(SECTION_HOTKEYS, "Cycle next character POV", new KeyboardShortcut(KeyCode.KeypadPlus));
+            CyclePrevHotkey = Config.Bind(SECTION_HOTKEYS, "Cycle previous character POV", new KeyboardShortcut(KeyCode.KeypadMinus));
+            IncludeFemalePOV = Config.Bind(SECTION_GENERAL, "Include female POV when cycling", false);
 
             Harmony.CreateAndPatchAll(GetType());
         }


### PR DESCRIPTION
Closes #30

Adds keyboard shortcuts for changing the current POV character in PlayHome, including female POV.
- Cycle next character hotkey ( Numpad + )
- Cycle previous character hotkey ( Numpad - )
- Toggle to include Female POV