### PR TITLE
Add support for subdirectories

### DIFF
--- a/src/BetterSceneLoader.Core/ImageGrid.cs
+++ b/src/BetterSceneLoader.Core/ImageGrid.cs
@@ -236,9 +236,9 @@ namespace BetterSceneLoader
             if(!File.Exists(defaultPath))
                 Directory.CreateDirectory(defaultPath);
 
-            var folders = Directory.GetDirectories(defaultPath).ToList();
+            var folders = Directory.GetDirectories(defaultPath, "*", SearchOption.AllDirectories).ToList();
             folders.Insert(0, defaultPath);
-
+            
             return folders.Select(x =>
             {
                 var filename = Path.GetFileName(x);


### PR DESCRIPTION
BetterSceneLoader could previously not load folders that were part of other subdirectories. This commit introduces a recursive way to get all folders for the dropdown selection.

I'll be honest, I noticed that problem by accident because I sort some of my files in some deeper folders, and wasn't able to select those folders.