### PR TITLE
Stop using obsoleted things

### DIFF
--- a/archive/FreeHControl.cs
+++ b/archive/FreeHControl.cs
@@ -22,8 +22,7 @@ namespace FreeHControl
 
         private void Awake()
         {
-            harmony = new Harmony($"{GUID}.harmony");
-            HarmonyWrapper.PatchAll(typeof(Hooks), harmony);
+            harmony = Harmony.CreateAndPatchAll(typeof(Hooks), $"{GUID}.harmony");
         }
 
 #if DEBUG

--- a/archive/Unlocker.cs
+++ b/archive/Unlocker.cs
@@ -34,8 +34,7 @@ namespace UnlockHPositions
 
         private void Awake()
         {
-            var harmony = new Harmony("keelhauled.unlockhpositions.harmony");
-            HarmonyWrapper.PatchAll(typeof(Hooks));
+            Harmony.CreateAndPatchAll(typeof(Hooks), "keelhauled.unlockhpositions.harmony");
         }
 
         private class Hooks

--- a/src/BuildSettings.Common.props
+++ b/src/BuildSettings.Common.props
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.18" />
   </ItemGroup>
   <Import Project="SkipAllRefs.targets" />
 </Project>

--- a/src/DefaultParamEditor.Core/SceneParam.cs
+++ b/src/DefaultParamEditor.Core/SceneParam.cs
@@ -30,7 +30,7 @@ namespace DefaultParamEditor.Koikatu
                 _sceneData.aceNo = sceneInfo.aceNo;
                 _sceneData.aceBlend = sceneInfo.aceBlend;
 
-                var aceInfo = UniversalAutoResolver.LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.LocalSlot == sceneInfo.aceNo);
+                var aceInfo = UniversalAutoResolver.GetStudioResolveInfos(sceneInfo.aceNo, true).FirstOrDefault();
                 if(aceInfo != null)
                 {
                     _sceneData.aceNo = aceInfo.Slot;
@@ -47,12 +47,14 @@ namespace DefaultParamEditor.Koikatu
                     if (prop.PropertyExists())
                     {
                         _sceneData.ace2No = prop.GetValue<int>();
-
-                        var ace2Info = UniversalAutoResolver.LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.LocalSlot == _sceneData.ace2No);
-                        if (ace2Info != null)
+                        if (_sceneData.ace2No.HasValue)
                         {
-                            _sceneData.ace2No = ace2Info.Slot;
-                            _sceneData.ace2No_GUID = ace2Info.GUID;
+                            var ace2Info = UniversalAutoResolver.GetStudioResolveInfos(_sceneData.ace2No.Value, true).FirstOrDefault();
+                            if (ace2Info != null)
+                            {
+                                _sceneData.ace2No = ace2Info.Slot;
+                                _sceneData.ace2No_GUID = ace2Info.GUID;
+                            }
                         }
                     }
                 }
@@ -121,7 +123,7 @@ namespace DefaultParamEditor.Koikatu
             sceneInfo.aceNo = _sceneData.aceNo;
             if(!string.IsNullOrEmpty(_sceneData.aceNo_GUID))
             {
-                var aceInfo = UniversalAutoResolver.LoadedStudioResolutionInfo.FirstOrDefault(x => x.GUID == _sceneData.aceNo_GUID && x.Slot == _sceneData.aceNo);
+                var aceInfo = UniversalAutoResolver.GetStudioResolveInfos(_sceneData.aceNo_GUID, _sceneData.aceNo, false).FirstOrDefault();
                 if(aceInfo != null)
                     sceneInfo.aceNo = aceInfo.LocalSlot;
             }
@@ -142,9 +144,9 @@ namespace DefaultParamEditor.Koikatu
                             {
                                 prop.SetValue(_sceneData.ace2No);
 
-                                if (!string.IsNullOrEmpty(_sceneData.ace2No_GUID))
+                                if (!string.IsNullOrEmpty(_sceneData.ace2No_GUID) && _sceneData.ace2No.HasValue)
                                 {
-                                    var ace2Info = UniversalAutoResolver.LoadedStudioResolutionInfo.FirstOrDefault(x => x.GUID == _sceneData.ace2No_GUID && x.Slot == _sceneData.ace2No);
+                                    var ace2Info = UniversalAutoResolver.GetStudioResolveInfos(_sceneData.ace2No_GUID, _sceneData.ace2No.Value, false).FirstOrDefault();
                                     if (ace2Info != null)
                                         prop.SetValue(ace2Info.LocalSlot);
                                 }


### PR DESCRIPTION
- BepInEx.Analyzers doesn't work, only spams crash messages. Replaced with an analyzer that works
- LoadedStudioResolutionInfo is obsolete and way slower than GetStudioResolveInfos
- Also changed HarmonyWrapper calls in archive because they show up on source searches and annoy me