### PR TITLE
Use AssemblyVersion instead of AssemblyFileVersion; Fill in missing file metadata

### DIFF
--- a/src/AltAutoMode.PlayHome/AltAutoMode.cs
+++ b/src/AltAutoMode.PlayHome/AltAutoMode.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-[assembly: System.Reflection.AssemblyFileVersion(AltAutoMode.PlayHome.AltAutoMode.Version)]
+[assembly: System.Reflection.AssemblyVersion(AltAutoMode.PlayHome.AltAutoMode.Version)]
 
 namespace AltAutoMode.PlayHome
 {

--- a/src/AnimeAssAssistant.Core/AAA.cs
+++ b/src/AnimeAssAssistant.Core/AAA.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 using System.Reflection.Emit;
 using System.Linq;
 
-[assembly: System.Reflection.AssemblyFileVersion(AnimeAssAssistant.AAA.Version)]
+[assembly: System.Reflection.AssemblyVersion(AnimeAssAssistant.AAA.Version)]
 
 namespace AnimeAssAssistant
 {

--- a/src/BetterSceneLoader.Core/BetterSceneLoader.cs
+++ b/src/BetterSceneLoader.Core/BetterSceneLoader.cs
@@ -5,7 +5,7 @@ using KeelPlugins;
 using KeelPlugins.Utils;
 using UILib;
 
-[assembly: System.Reflection.AssemblyFileVersion(BetterSceneLoader.BetterSceneLoader.Version)]
+[assembly: System.Reflection.AssemblyVersion(BetterSceneLoader.BetterSceneLoader.Version)]
 
 namespace BetterSceneLoader
 {

--- a/src/BlendShaper.Koikatu/BlendShaper.cs
+++ b/src/BlendShaper.Koikatu/BlendShaper.cs
@@ -6,7 +6,7 @@ using UILib;
 using UnityEngine;
 using UnityEngine.UI;
 
-[assembly: System.Reflection.AssemblyFileVersion(BlendShaper.Koikatu.BlendShaper.Version)]
+[assembly: System.Reflection.AssemblyVersion(BlendShaper.Koikatu.BlendShaper.Version)]
 
 //cf_O_canine
 //cf_O_face

--- a/src/BuildSettings.Common.props
+++ b/src/BuildSettings.Common.props
@@ -1,10 +1,16 @@
 <Project>
   <PropertyGroup>
     <DebugType>embedded</DebugType>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(SolutionDir)bin\$(Configuration)</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Company>https://github.com/IllusionMods/KeelPlugins</Company>
+    <Copyright>GPL-3.0 license, 2019</Copyright>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.18" />

--- a/src/CameraFrameMask.Core/CameraFrameMask.cs
+++ b/src/CameraFrameMask.Core/CameraFrameMask.cs
@@ -3,7 +3,7 @@ using HarmonyLib;
 using Studio;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(CameraFrameMask.Koikatu.CameraFrameMask.Version)]
+[assembly: System.Reflection.AssemblyVersion(CameraFrameMask.Koikatu.CameraFrameMask.Version)]
 
 namespace CameraFrameMask.Koikatu
 {

--- a/src/CharaStateX.Core/CharaStateX.cs
+++ b/src/CharaStateX.Core/CharaStateX.cs
@@ -2,7 +2,7 @@
 using HarmonyLib;
 using KeelPlugins;
 
-[assembly: System.Reflection.AssemblyFileVersion(CharaStateX.Koikatu.CharaStateX.Version)]
+[assembly: System.Reflection.AssemblyVersion(CharaStateX.Koikatu.CharaStateX.Version)]
 
 namespace CharaStateX.Koikatu
 {

--- a/src/ClothingStateMenuX.Core/ClothingStateMenu.cs
+++ b/src/ClothingStateMenuX.Core/ClothingStateMenu.cs
@@ -7,7 +7,7 @@ using KeelPlugins;
 using KKAPI;
 using KKAPI.Maker;
 
-[assembly: System.Reflection.AssemblyFileVersion(ClothingStateMenuX.ClothingStateMenu.Version)]
+[assembly: System.Reflection.AssemblyVersion(ClothingStateMenuX.ClothingStateMenu.Version)]
 
 namespace ClothingStateMenuX
 {

--- a/src/DefaultParamEditor.Core/DefaultParamEditor.cs
+++ b/src/DefaultParamEditor.Core/DefaultParamEditor.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
 
-[assembly: System.Reflection.AssemblyFileVersion(DefaultParamEditor.Koikatu.DefaultParamEditor.Version)]
+[assembly: System.Reflection.AssemblyVersion(DefaultParamEditor.Koikatu.DefaultParamEditor.Version)]
 
 namespace DefaultParamEditor.Koikatu
 {

--- a/src/DefaultStudioScene.Core/DefaultStudioScene.cs
+++ b/src/DefaultStudioScene.Core/DefaultStudioScene.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 using KKAPI.Utilities;
 using KeelPlugins;
 
-[assembly: System.Reflection.AssemblyFileVersion(DefaultStudioScene.Koikatu.DefaultStudioScene.Version)]
+[assembly: System.Reflection.AssemblyVersion(DefaultStudioScene.Koikatu.DefaultStudioScene.Version)]
 
 namespace DefaultStudioScene.Koikatu
 {

--- a/src/EyeLookEditor.Core/EyeLookEditor.cs
+++ b/src/EyeLookEditor.Core/EyeLookEditor.cs
@@ -5,7 +5,7 @@ using KKAPI.Maker.UI;
 using System;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(EyeLookEditor.EyeLookEditor.Version)]
+[assembly: System.Reflection.AssemblyVersion(EyeLookEditor.EyeLookEditor.Version)]
 
 namespace EyeLookEditor
 {

--- a/src/FavoriteCards.Koikatu/Favorite.cs
+++ b/src/FavoriteCards.Koikatu/Favorite.cs
@@ -5,7 +5,7 @@ using KKAPI.Utilities;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
-[assembly: System.Reflection.AssemblyFileVersion(FavoriteCards.Koikatu.Favorite.Version)]
+[assembly: System.Reflection.AssemblyVersion(FavoriteCards.Koikatu.Favorite.Version)]
 
 namespace FavoriteCards.Koikatu
 {

--- a/src/FreeHDefaults.Core/FreeHDefaults.cs
+++ b/src/FreeHDefaults.Core/FreeHDefaults.cs
@@ -14,7 +14,7 @@ using Manager;
 using UniRx;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(FreeHDefaults.Koikatu.FreeHDefaults.Version)]
+[assembly: System.Reflection.AssemblyVersion(FreeHDefaults.Koikatu.FreeHDefaults.Version)]
 
 namespace FreeHDefaults.Koikatu
 {

--- a/src/ItemLayerEdit.Core/ItemLayerEdit.cs
+++ b/src/ItemLayerEdit.Core/ItemLayerEdit.cs
@@ -6,7 +6,7 @@ using Studio;
 using System.Linq;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(ItemLayerEdit.Koikatu.ItemLayerEdit.Version)]
+[assembly: System.Reflection.AssemblyVersion(ItemLayerEdit.Koikatu.ItemLayerEdit.Version)]
 
 namespace ItemLayerEdit.Koikatu
 {

--- a/src/LightManager.Core/LightManagerPlugin.cs
+++ b/src/LightManager.Core/LightManagerPlugin.cs
@@ -4,7 +4,7 @@ using KeelPlugins;
 using KKAPI.Studio.SaveLoad;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(LightManager.Koikatu.LightManagerPlugin.Version)]
+[assembly: System.Reflection.AssemblyVersion(LightManager.Koikatu.LightManagerPlugin.Version)]
 
 namespace LightManager.Koikatu
 {

--- a/src/LockOnPlugin.Core/LockOnPluginCore.cs
+++ b/src/LockOnPlugin.Core/LockOnPluginCore.cs
@@ -8,7 +8,7 @@ using KKAPI.Studio;
 using System;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(LockOnPlugin.LockOnPluginCore.Version)]
+[assembly: System.Reflection.AssemblyVersion(LockOnPlugin.LockOnPluginCore.Version)]
 
 namespace LockOnPlugin
 {

--- a/src/MakerBridge.Core/MakerBridge.cs
+++ b/src/MakerBridge.Core/MakerBridge.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 using KKAPI.Maker;
 using KKAPI.Studio;
 
-[assembly: System.Reflection.AssemblyFileVersion(MakerBridge.MakerBridge.Version)]
+[assembly: System.Reflection.AssemblyVersion(MakerBridge.MakerBridge.Version)]
 
 namespace MakerBridge
 {

--- a/src/MaterialLink.KoikatuSunshine/MaterialLink.cs
+++ b/src/MaterialLink.KoikatuSunshine/MaterialLink.cs
@@ -4,7 +4,7 @@ using BepInEx;
 using HarmonyLib;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(MaterialLink.KoikatuSunshine.MaterialLinkInfo.Version)]
+[assembly: System.Reflection.AssemblyVersion(MaterialLink.KoikatuSunshine.MaterialLinkInfo.Version)]
 
 namespace MaterialLink.KoikatuSunshine
 {

--- a/src/RealPOV.Core.Koikatu/RealPOV.cs
+++ b/src/RealPOV.Core.Koikatu/RealPOV.cs
@@ -10,7 +10,7 @@ using KKAPI.Studio.SaveLoad;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-[assembly: System.Reflection.AssemblyFileVersion(RealPOV.Koikatu.RealPOV.Version)]
+[assembly: System.Reflection.AssemblyVersion(RealPOV.Koikatu.RealPOV.Version)]
 
 namespace RealPOV.Koikatu
 {

--- a/src/RealPOV.PlayHome/RealPOV.cs
+++ b/src/RealPOV.PlayHome/RealPOV.cs
@@ -6,7 +6,7 @@ using KeelPlugins.Utils;
 using RealPOV.Core;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(RealPOV.PlayHome.RealPOV.Version)]
+[assembly: System.Reflection.AssemblyVersion(RealPOV.PlayHome.RealPOV.Version)]
 
 namespace RealPOV.PlayHome
 {

--- a/src/SoundEffects.PlayHome/SoundEffects.cs
+++ b/src/SoundEffects.PlayHome/SoundEffects.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(SoundEffects.PlayHome.SoundEffects.Version)]
+[assembly: System.Reflection.AssemblyVersion(SoundEffects.PlayHome.SoundEffects.Version)]
 
 namespace SoundEffects.PlayHome
 {

--- a/src/StudioAddonLite.Core/StudioAddonLite.cs
+++ b/src/StudioAddonLite.Core/StudioAddonLite.cs
@@ -4,7 +4,7 @@ using HarmonyLib;
 using KeelPlugins;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(StudioAddonLite.Koikatu.StudioAddonLite.Version)]
+[assembly: System.Reflection.AssemblyVersion(StudioAddonLite.Koikatu.StudioAddonLite.Version)]
 
 namespace StudioAddonLite.Koikatu
 {

--- a/src/TesselationSetting.KoikatuSunshine/TesselationSetting.cs
+++ b/src/TesselationSetting.KoikatuSunshine/TesselationSetting.cs
@@ -5,7 +5,7 @@ using KeelPlugins;
 using KKAPI;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(TesselationSetting.Koikatu.TesselationSetting.Version)]
+[assembly: System.Reflection.AssemblyVersion(TesselationSetting.Koikatu.TesselationSetting.Version)]
 
 namespace TesselationSetting.Koikatu
 {

--- a/src/TitleShortcuts.AISyoujyo/TitleShortcuts.cs
+++ b/src/TitleShortcuts.AISyoujyo/TitleShortcuts.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 
-[assembly: System.Reflection.AssemblyFileVersion(TitleShortcuts.AISyoujyo.TitleShortcuts.Version)]
+[assembly: System.Reflection.AssemblyVersion(TitleShortcuts.AISyoujyo.TitleShortcuts.Version)]
 
 namespace TitleShortcuts.AISyoujyo
 {

--- a/src/TitleShortcuts.HoneySelect2/TitleShortcuts.cs
+++ b/src/TitleShortcuts.HoneySelect2/TitleShortcuts.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 
-[assembly: System.Reflection.AssemblyFileVersion(TitleShortcuts.HoneySelect2.TitleShortcuts.Version)]
+[assembly: System.Reflection.AssemblyVersion(TitleShortcuts.HoneySelect2.TitleShortcuts.Version)]
 
 namespace TitleShortcuts.HoneySelect2
 {

--- a/src/TitleShortcuts.Koikatu/TitleShortcuts.cs
+++ b/src/TitleShortcuts.Koikatu/TitleShortcuts.cs
@@ -8,7 +8,7 @@ using KeelPlugins.Harmony;
 using TitleShortcuts.Core;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(TitleShortcuts.Koikatu.TitleShortcuts.Version)]
+[assembly: System.Reflection.AssemblyVersion(TitleShortcuts.Koikatu.TitleShortcuts.Version)]
 
 namespace TitleShortcuts.Koikatu
 {

--- a/src/TitleShortcuts.KoikatuSunshine/TitleShortcuts.cs
+++ b/src/TitleShortcuts.KoikatuSunshine/TitleShortcuts.cs
@@ -7,7 +7,7 @@ using System.Collections;
 using TitleShortcuts.Core;
 using UnityEngine;
 
-[assembly: System.Reflection.AssemblyFileVersion(TitleShortcuts.KoikatuSunshine.TitleShortcuts.Version)]
+[assembly: System.Reflection.AssemblyVersion(TitleShortcuts.KoikatuSunshine.TitleShortcuts.Version)]
 
 namespace TitleShortcuts.KoikatuSunshine
 {

--- a/src/UnityLogFilter/UnityLogFilter.cs
+++ b/src/UnityLogFilter/UnityLogFilter.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-[assembly: System.Reflection.AssemblyFileVersion(UnityLogFilter.UnityLogFilter.Version)]
+[assembly: System.Reflection.AssemblyVersion(UnityLogFilter.UnityLogFilter.Version)]
 
 namespace UnityLogFilter
 {


### PR DESCRIPTION
Setting AssemblyVersion automatically assigns it as file version as long as AssemblyFileVersion is not being generated.
Disable generating InformationalVersion as well since it's functionally useless as it always shows 1.0.0 + some hash, not the real version or commit ID.